### PR TITLE
fix: unquoted csv writer

### DIFF
--- a/frontend/rctool/views.py
+++ b/frontend/rctool/views.py
@@ -971,7 +971,7 @@ def rctool_export_output(request):
                         },
                     )
 
-                    writer = csv.writer(response)
+                    writer = csv.writer(response, quoting=csv.QUOTE_ALL)
                     writer.writerow(["RATING CURVE OUTPUT SUMMARY"])
                     writer.writerow(
                         [


### PR DESCRIPTION
Recommended by Snyk.

`Unsanitized input from a web form flows into an unquoted CSV-writer (csv.writer). Use quoting=csv.QUOTE_ALL when the input is flowing from an untrusted source.`

Docs/reference
https://docs.python.org/3/library/csv.html#csv.writer

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-147-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)