### PR TITLE
chore(ci): remove .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-# Dependency updates for GitHub Actions and npm
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
We're using Renovate for dependencies.  Removing .github/dependabot.yml will hopefully shut down Dependabot PRs.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-168-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-168-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)