### PR TITLE
fix: Revert "chore(ci): deployment config deprecation"

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -68,24 +68,33 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - apiVersion: apps/v1
-    kind: Deployment
+  - apiVersion: v1
+    kind: DeploymentConfig
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        matchLabels:
-          deployment: ${NAME}-${ZONE}-${COMPONENT}
+        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: RollingUpdate
+        type: Rolling
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deployment: ${NAME}-${ZONE}-${COMPONENT}
+            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
@@ -156,7 +165,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
 
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
@@ -165,7 +174,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: Deployment
+        kind: DeploymentConfig
         name: ${NAME}-${ZONE}-${COMPONENT}
       minReplicas: ${{MIN_REPLICAS}}
       maxReplicas: ${{MAX_REPLICAS}}

--- a/frontend/openshift.nginx.deploy.yml
+++ b/frontend/openshift.nginx.deploy.yml
@@ -55,24 +55,33 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - apiVersion: apps/v1
-    kind: Deployment
+  - apiVersion: v1
+    kind: DeploymentConfig
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        matchLabels:
-          deployment: ${NAME}-${ZONE}-${COMPONENT}
+        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: RollingUpdate
+        type: Rolling
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deployment: ${NAME}-${ZONE}-${COMPONENT}
+            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           containers:
             - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
@@ -123,7 +132,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -148,7 +157,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: Deployment
+        kind: DeploymentConfig
         name: ${NAME}-${ZONE}-${COMPONENT}
       minReplicas: ${{MIN_REPLICAS}}
       maxReplicas: ${{MAX_REPLICAS}}


### PR DESCRIPTION
Reverts bcgov/nr-hydrometric-rating-curve#170

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-171-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)