### PR TITLE
fix(ci): allow Trivy to fail w/o blocking (temporary)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,7 +82,8 @@ jobs:
             
   results:
     name: Analysis Results
-    needs: [codeql, trivy, tests]
+    # needs: [codeql, trivy, tests] # Restore trivy when it's working again
+    needs: [codeql, tests]
     runs-on: ubuntu-22.04
     steps:
       - run: echo "Workflow completed successfully!"


### PR DESCRIPTION
Trivy has been having problems, so it has been removed from Analysis Results needs in analysis.yml.  Ideally this can be restored when they're no longer having issues.

```
  results:
    name: Analysis Results
    needs: [codeql, trivy, tests] # Here!
```

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-207-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)