### PR TITLE
feat(ci): handle job fails, skips in Analysis Results

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,6 +82,7 @@ jobs:
             
   results:
     name: Analysis Results
+    if: always()
     needs: [codeql, tests] # Restore trivy when it's working again
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,8 +82,9 @@ jobs:
             
   results:
     name: Analysis Results
-    # needs: [codeql, trivy, tests] # Restore trivy when it's working again
-    needs: [codeql, tests]
+    needs: [codeql, tests] # Restore trivy when it's working again
     runs-on: ubuntu-22.04
     steps:
-      - run: echo "Workflow completed successfully!"
+      - if: contains(needs.*.result, 'failure')
+        run: echo "At least one job has failed." && exit 1
+      - run: echo "Success!"


### PR DESCRIPTION
This adds checks for all needs in Analysis Results, allowing skips, but hard blocking on failures.  It's now flexible enough to support conditional jobs and ommissions, like Trivy, which has been failing lately.  (See #207)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-208-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)