### PR TITLE
chore: Revert "chore(deps): update bcgov/quickstart-openshift-helpers action to v0.10.0"

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,7 +27,7 @@ jobs:
 
   deploy-test:
     name: Deploy (TEST)
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
   deploy-prod:
     name: Deploy (PROD)
     needs: [vars, deploy-test]
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   cleanup:
     name: Cleanup and Images
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -38,7 +38,7 @@ jobs:
   deploys:
     name: Deploys
     needs: [ builds ]
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   validate:
     name: Validate PR
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.9.0
     with:
       markdown_links: |
         - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/) available


### PR DESCRIPTION
Reverts bcgov/nr-hydrometric-rating-curve#258

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-260-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)