### PR TITLE
chore(ci): use bcgov action runner

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,46 +19,37 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1
-        with:
-          oc: "4.14.37"
-
       - name: Clean up Helm Releases
-        run: |
-          # OC Login
-          OC_TEMP_TOKEN=$(curl -k -X POST ${{ inputs.oc_server }}/api/v1/namespaces/${{ secrets.oc_namespace }}/serviceaccounts/pipeline/token --header "Authorization: Bearer ${{ secrets.oc_token }}" -d '{"spec": {"expirationSeconds": 600}}' -H 'Content-Type: application/json; charset=utf-8' | jq -r '.status.token' )
+        uses: bcgov/action-oc-runner@v1.2.3 # v1.2.3
+        with:
+          oc_server: ${{ vars.oc_server }}
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_token: ${{ secrets.oc_token }}
+          commands: |
+            # Echos
+            echo "Delete stale Helm releases"
+            echo "Cutoff: ${{ env.CUTOFF }}"
 
-          oc login --token=$OC_TEMP_TOKEN --server=${{ inputs.oc_server }}
-          oc project ${{ secrets.oc_namespace }} # Safeguard!
+            # Before date, list of releases
+            BEFORE=$(date +%s -d "${{ env.CUTOFF }}")
+            RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }} || :)
 
-          # Catch errors, unset variables, and pipe failures (e.g. grep || true )
-          set -euo pipefail
+            # If releases, then iterate
+            [ -z "${RELEASES}" ]|| for r in ${RELEASES[@]}; do
 
-          # Echos
-          echo "Delete stale Helm releases"
-          echo "Cutoff: ${{ env.CUTOFF }}"
+              # Get last update and convert the date
+              UPDATED=$(date "+%s" -d <<< echo $(helm status $r -o json | jq -r .info.last_deployed))
 
-          # Before date, list of releases
-          BEFORE=$(date +%s -d "${{ env.CUTOFF }}")
-          RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }} || :)
-
-          # If releases, then iterate
-          [ -z "${RELEASES}" ]|| for r in ${RELEASES[@]}; do
-
-            # Get last update and convert the date
-            UPDATED=$(date "+%s" -d <<< echo $(helm status $r -o json | jq -r .info.last_deployed))
-
-            # Compare to cutoff and delete as necessary
-            if [[ ${UPDATED} < ${BEFORE} ]]; then
-              echo -e "\nOlder than cutoff: ${r}"
-              helm uninstall --no-hooks ${r}
-              oc delete pvc/${r}-bitnami-pg-0
-            else
-              echo -e "\nNewer than cutoff: ${r}"
-              echo "No need to delete"
-            fi
-          done
+              # Compare to cutoff and delete as necessary
+              if [[ ${UPDATED} < ${BEFORE} ]]; then
+                echo -e "\nOlder than cutoff: ${r}"
+                helm uninstall --no-hooks ${r}
+                oc delete pvc/${r}-bitnami-pg-0
+              else
+                echo -e "\nNewer than cutoff: ${r}"
+                echo "No need to delete"
+              fi
+            done
 
   zap_scan:
     runs-on: ubuntu-24.04

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Clean up Helm Releases
-        uses: bcgov/action-oc-runner@v1.2.3 # v1.2.3
+        uses: bcgov/action-oc-runner@10033668ef4374d9bb78149faa73e4ccda0e93dd # v1.2.3
         with:
           oc_server: ${{ vars.oc_server }}
           oc_namespace: ${{ secrets.oc_namespace }}


### PR DESCRIPTION
Use bcgov/action-oc-runner instead of the old red hat action.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-277-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)