### PR TITLE
chore(ci): provide non-default Helm namespace

### DIFF
--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "frontend.fullname" . }}
-  namespace: {{ .Values.namespace | default .Values.repository }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "frontend.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "frontend.fullname" . }}
-  namespace: {{ .Values.namespace | default ".Values.repository" }}
+  namespace: {{ .Values.namespace | default .Values.repository }}
   labels:
     {{- include "frontend.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "frontend.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "frontend.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "frontend.fullname" . }}
+  namespace: {{ .Values.namespace | default ".Values.repository" }}
   labels:
     {{- include "frontend.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/rctool/templates/deployment.yaml
+++ b/charts/app/templates/rctool/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rctool.fullname" . }}
+  namespace: {{ .Values.namespace | default ".Values.repository" }}
   labels:
     {{- include "rctool.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/rctool/templates/deployment.yaml
+++ b/charts/app/templates/rctool/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rctool.fullname" . }}
-  namespace: {{ .Values.namespace | default .Values.repository }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "rctool.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/rctool/templates/deployment.yaml
+++ b/charts/app/templates/rctool/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rctool.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "rctool.labels" . | nindent 4 }}
 spec:

--- a/charts/app/templates/rctool/templates/deployment.yaml
+++ b/charts/app/templates/rctool/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rctool.fullname" . }}
-  namespace: {{ .Values.namespace | default ".Values.repository" }}
+  namespace: {{ .Values.namespace | default .Values.repository }}
   labels:
     {{- include "rctool.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Provide a non-default namespace to Helm.  Addresses two alerts.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-280-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)