### PR TITLE
chore: Revert "chore(deps): update bcgov/quickstart-openshift-helpers action to v1"

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,7 +30,7 @@ jobs:
 
   deploy-test:
     name: Deploy (TEST)
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@0b8121a528aaa05ef8def2f79be9081691dfe98a # v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
   deploy-prod:
     name: Deploy (PROD)
     needs: [vars, deploy-test]
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@0b8121a528aaa05ef8def2f79be9081691dfe98a # v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -16,7 +16,7 @@ jobs:
     name: Cleanup and Images
     permissions:
       packages: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@0b8121a528aaa05ef8def2f79be9081691dfe98a # v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,7 @@ jobs:
     needs: [builds]
     permissions:
       packages: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.deployer.yml@0b8121a528aaa05ef8def2f79be9081691dfe98a # v0.9.0
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -15,7 +15,7 @@ jobs:
     name: Validate PR
     permissions:
       pull-requests: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@d9b3d32fb3f03c4699c2dce83ddfff042cd31a1f # v1.0.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@0b8121a528aaa05ef8def2f79be9081691dfe98a # v0.9.0
     with:
       markdown_links: |
         - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}-frontend.apps.silver.devops.gov.bc.ca/) available


### PR DESCRIPTION
Reverts bcgov/nr-hydrometric-rating-curve#289

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-292-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)