### PR TITLE
fix: resolve JavaScript syntax error in import page template

### DIFF
--- a/frontend/rctool/templates/rctool/rctool/import/rctool_import.html
+++ b/frontend/rctool/templates/rctool/rctool/import/rctool_import.html
@@ -168,8 +168,7 @@
     // Check if tour status has been previously set
     if (sessionStorage.getItem("tourStatus") == null) {
         // Check if user selected tour
-        var tourStatusID = {{ tour_request_status_id| safe
-    }};
+        var tourStatusID = {{ tour_request_status_id | safe }};
     if (tourStatusID == 1) {
         sessionStorage.setItem("tourStatus", true);
     } else {


### PR DESCRIPTION
The tour_request_status_id template variable was split across two lines,
causing invalid JavaScript (Unexpected token '{'). This broke the submit
button functionality on the import page.

Fixes the error: Uncaught SyntaxError: Unexpected token '{' (at 0/:256:29)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-317-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)