### PR TITLE
chore(infra): route nginx logs to stdout/stderr and fix rctool securityContext indentation

### DIFF
--- a/charts/app/templates/rctool/templates/deployment.yaml
+++ b/charts/app/templates/rctool/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           - name: {{ include "rctool.fullname" . }}
             {{- if .Values.rctool.containerSecurityContext }}
             securityContext:
-              {{- toYaml .Values.rctool.containerSecurityContext | nindent 12 }}
+              {{- toYaml .Values.rctool.containerSecurityContext | nindent 14 }}
             {{- end }}
             image: "{{.Values.global.registry}}/{{.Values.global.repository}}/rctool:{{ .Values.global.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ default "Always" .Values.rctool.imagePullPolicy }}

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,6 +1,6 @@
 # Tell nginx to use custom locations for runtime files
 pid /tmp/nginx.pid;             # Store PID file in /tmp (writable by any user)
-error_log /dev/stderr info;       # Store error log in /dev/stderr for proper container logging
+error_log /tmp/error.log;       # Store error log in /tmp (writable by any user)
 
 # Events block: controls basic connection processing
 events {
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    access_log /dev/stdout; # Store access log in /dev/stdout for proper container logging
+    access_log /tmp/access.log; # Store access log in /tmp (writable by any user)
 
     # Use system mime.types for file type detection
     include /etc/nginx/mime.types;

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,6 +1,6 @@
 # Tell nginx to use custom locations for runtime files
 pid /tmp/nginx.pid;             # Store PID file in /tmp (writable by any user)
-error_log /tmp/error.log;       # Store error log in /tmp (writable by any user)
+error_log /dev/stderr info;       # Store error log in /dev/stderr for proper container logging
 
 # Events block: controls basic connection processing
 events {
@@ -8,7 +8,7 @@ events {
 }
 
 http {
-    access_log /tmp/access.log; # Store access log in /tmp (writable by any user)
+    access_log /dev/stdout; # Store access log in /dev/stdout for proper container logging
 
     # Use system mime.types for file type detection
     include /etc/nginx/mime.types;

--- a/frontend/start_nginx.sh
+++ b/frontend/start_nginx.sh
@@ -13,6 +13,13 @@ cat /tmp/nginx.conf | sed 's/ /·/g'
 # Create temp dirs
 mkdir -p /tmp/nginx-proxy-temp /tmp/nginx-client-temp /tmp/nginx-fastcgi-temp /tmp/nginx-uwsgi-temp /tmp/nginx-scgi-temp
 
+# Touch log files to ensure they exist for tail
+touch /tmp/access.log /tmp/error.log
+
+# Stream logs to stdout and stderr in background for container observability
+tail -F /tmp/access.log &
+tail -F /tmp/error.log >&2 &
+
 # Startup (daemon off = foreground)
 echo
 echo "---> Starting nginx"


### PR DESCRIPTION
This PR resolves two infrastructure issues:
1. Routes Nginx error and access logs to /dev/stderr and /dev/stdout for proper Kubernetes/OpenShift container logs visibility.
2. Corrects Helm chart template indentation for the rctool container's securityContext to prevent Kubernetes API warnings.

Closes #343

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-hydrometric-rating-curve-344-frontend.apps.silver.devops.gov.bc.ca/) available


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-hydrometric-rating-curve/actions/workflows/merge.yml)